### PR TITLE
Test all possible Unicode code points

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Jo Liss <joliss42@gmail.com>",
   "license": "MIT",
   "devDependencies" : {
-    "tap": "~> 0.4.2"
+    "tap": "~> 0.4.2",
+    "punycode": "~> 1.2.1"
   }
 }


### PR DESCRIPTION
The README already claimed we did (see #1), so why not.

This uses Punycode.js which ships with Node. There’s no need to install it as a dependency!
