### PR TITLE
Slim npm distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   },
   "engines": {
     "node": ">= 0.8"
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
At present, the `CHANGELOG.md` file and the `test` directory are being distributed via npm.

The package is currently 6.89kb once downloaded.

Adding this change will reduce it to around 2kb.
